### PR TITLE
Potential fix for code scanning alert no. 173: DOM text reinterpreted as HTML

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -36,7 +36,8 @@
     "react-router-dom": "^6.24.1",
     "react-scripts": "^5.0.1",
     "react-spinners": "^0.15.0",
-    "react-toastify": "^11.0.3"
+    "react-toastify": "^11.0.3",
+    "dompurify": "^3.2.4"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/client/src/components/vendor/VendorProfile.jsx
+++ b/client/src/components/vendor/VendorProfile.jsx
@@ -17,6 +17,7 @@ import VendorTeamLeave from './VendorTeamLeave';
 import { toast } from 'react-toastify';
 import PhoneInput from 'react-phone-number-input'
 import 'react-phone-number-input/style.css'
+import DOMPurify from 'dompurify';
 
 function VendorProfile () {
     const { id } = useParams();
@@ -1178,7 +1179,7 @@ function VendorProfile () {
                                             <>
                                                 <img
                                                     className='img-vendor-edit'
-                                                    src={tempVendorData.image ? `/vendor-images/${tempVendorData.image}` : `/vendor-images/_default-images/${tempVendorData.image_default}`}
+                                                    src={tempVendorData.image ? `/vendor-images/${DOMPurify.sanitize(tempVendorData.image)}` : `/vendor-images/_default-images/${tempVendorData.image_default}`}
                                                     alt="Vendor"
                                                     style={{ maxWidth: '100%', height: 'auto' }}
                                                 />


### PR DESCRIPTION
Potential fix for [https://github.com/zaklance/Project-Gingham/security/code-scanning/173](https://github.com/zaklance/Project-Gingham/security/code-scanning/173)

To fix the problem, we need to ensure that the value of `tempVendorData.image` is properly sanitized before being used in the `src` attribute of the `img` element. One way to achieve this is by using a library like `DOMPurify` to sanitize the input. This will help prevent any malicious content from being executed.

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the file.
3. Use `DOMPurify` to sanitize the value of `tempVendorData.image` before using it in the `src` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
