### PR TITLE
Potential fix for code scanning alert no. 147: Flask app is run in debug mode

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -5142,5 +5142,5 @@ def export_pdf_vendor_baskets():
         return jsonify({"error": f"Error fetching baskets: {str(e)}"}), 500
 
 if __name__ == '__main__':
-    # app.run(host="0.0.0.0", port=5555, debug=True)
-    app.run(port=5555, debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(port=5555, debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/zaklance/Project-Gingham/security/code-scanning/147](https://github.com/zaklance/Project-Gingham/security/code-scanning/147)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. This can be achieved by using an environment variable to control the debug mode. By default, the application should run with `debug=False`, and only enable debug mode if explicitly set in the environment.

1. Modify the `app.run` call to use an environment variable to determine the debug mode.
2. Update the code to read the environment variable and set the debug mode accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
