### PR TITLE
Potential fix for code scanning alert no. 174: DOM text reinterpreted as HTML

### DIFF
--- a/client/src/components/vendor/VendorProfile.jsx
+++ b/client/src/components/vendor/VendorProfile.jsx
@@ -19,6 +19,15 @@ import PhoneInput from 'react-phone-number-input'
 import 'react-phone-number-input/style.css'
 import DOMPurify from 'dompurify';
 
+function escapeHtml(unsafe) {
+    return unsafe
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
 function VendorProfile () {
     const { id } = useParams();
     const [editMode, setEditMode] = useState(false);
@@ -1179,7 +1188,7 @@ function VendorProfile () {
                                             <>
                                                 <img
                                                     className='img-vendor-edit'
-                                                    src={tempVendorData.image ? `/vendor-images/${DOMPurify.sanitize(tempVendorData.image)}` : `/vendor-images/_default-images/${tempVendorData.image_default}`}
+                                                    src={tempVendorData.image ? `/vendor-images/${escapeHtml(DOMPurify.sanitize(tempVendorData.image))}` : `/vendor-images/_default-images/${tempVendorData.image_default}`}
                                                     alt="Vendor"
                                                     style={{ maxWidth: '100%', height: 'auto' }}
                                                 />


### PR DESCRIPTION
Potential fix for [https://github.com/zaklance/Project-Gingham/security/code-scanning/174](https://github.com/zaklance/Project-Gingham/security/code-scanning/174)

To fix the problem, we need to ensure that the sanitized text is properly escaped before being embedded into the HTML. This can be achieved by using a function that escapes special characters in the sanitized text to prevent it from being interpreted as HTML.

- We will create a utility function to escape special characters in the sanitized text.
- We will use this utility function to escape the `tempVendorData.image` value before embedding it into the HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
