### PR TITLE
Potential fix for code scanning alert no. 182: DOM text reinterpreted as HTML

### DIFF
--- a/client/src/components/vendor/VendorProfile.jsx
+++ b/client/src/components/vendor/VendorProfile.jsx
@@ -19,14 +19,7 @@ import PhoneInput from 'react-phone-number-input'
 import 'react-phone-number-input/style.css'
 import DOMPurify from 'dompurify';
 
-function escapeHtml(unsafe) {
-    return unsafe
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#039;");
-}
+
 
 function VendorProfile () {
     const { id } = useParams();
@@ -1188,7 +1181,7 @@ function VendorProfile () {
                                             <>
                                                 <img
                                                     className='img-vendor-edit'
-                                                    src={tempVendorData.image ? `/vendor-images/${escapeHtml(DOMPurify.sanitize(tempVendorData.image))}` : `/vendor-images/_default-images/${tempVendorData.image_default}`}
+                                                    src={tempVendorData.image ? `/vendor-images/${DOMPurify.sanitize(tempVendorData.image, { SAFE_FOR_TEMPLATES: true })}` : `/vendor-images/_default-images/${tempVendorData.image_default}`}
                                                     alt="Vendor"
                                                     style={{ maxWidth: '100%', height: 'auto' }}
                                                 />


### PR DESCRIPTION
Potential fix for [https://github.com/zaklance/Project-Gingham/security/code-scanning/182](https://github.com/zaklance/Project-Gingham/security/code-scanning/182)

To fix the problem, we should ensure that the user input is properly sanitized and escaped before being used in the HTML context. Instead of using a combination of `DOMPurify.sanitize` and `escapeHtml`, we can use `DOMPurify.sanitize` with the `SAFE_FOR_TEMPLATES` configuration to ensure that the input is safe for use in template literals. This configuration is specifically designed to handle cases where sanitized text is used in HTML templates.

1. Update the `DOMPurify.sanitize` call to use the `SAFE_FOR_TEMPLATES` configuration.
2. Remove the `escapeHtml` function as it will no longer be necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
